### PR TITLE
Allow re-register handler

### DIFF
--- a/nidsmodule.c
+++ b/nidsmodule.c
@@ -533,9 +533,8 @@ pynids_register_##WHAT (PyObject *na, PyObject *args) 			\
 	if (FP != NULL) {											\
 		/* (re-)set single, global func ptr */					\
 		PyObject_Del(FP);										\
-	} else {													\
-		nids_register_##WHAT(PYDISPATCH);						\
 	}															\
+	nids_register_##WHAT(PYDISPATCH);							\
 	DBG("Inside register_" #WHAT "(%p)\n", pyFunc);				\
 	FP = pyFunc;												\
 	Py_INCREF(FP);												\


### PR DESCRIPTION
A handler isn't re-registered after the end of run() unregisters it
See: https://stackoverflow.com/questions/20127131/using-pynids-on-multiple-pcaps

I'm not sure whether this is right, but for a quick solution it seems to be fine.

See similar bug: https://rt.cpan.org/Public/Bug/Display.html?id=51107
